### PR TITLE
Jblakeman solution

### DIFF
--- a/final_countdown.js
+++ b/final_countdown.js
@@ -1,33 +1,46 @@
 $(document).ready(function() {
-    var counter = $("#counter");
-    var startCount = "1234";
-    var started = false;
-    var zeroClass = "fail";
-    var count, queue;
-    counter.val(startCount);
-    function countDown() {
-        count--;
-        if (count === 0) {
-            started = false;
-            counter.addClass(zeroClass);
-            clearInterval(queue);
-        } else {
-            if (counter.hasClass(zeroClass)) counter.removeClass(zeroClass);
-        }
-        counter.val(count);
+    var count, counterID;
+    function Counter(selector, value, failClass, delay) {
+        this.el = $(selector);
+        this.startNum = value;
+        this.count = value;
+        this.started = false;
+        this.failClass = failClass;
+        this.delay = delay;
     }
-    counter.on("click", function(event) {
-        event.preventDefault();
-        if (started) {
-            started = false;
-            clearInterval(queue);
+    Counter.prototype.countDown = function() {
+        if (this.count === 0) {
+            this.started = false;
+            this.el.addClass(this.failClass);
+            this.stopCounting();
         } else {
-            started = true;
-            count = startCount;
-            counter.val(startCount);
-            // The following should behave the same as setting the delay to 0
-            // in browsers that follow the HTML5 spec.
-            queue = setInterval(countDown, 4);
+            this.count--;
+            this.el.val(this.count);
+            if (this.el.hasClass(this.failClass)) {
+                this.el.removeClass(this.failClass);
+            }
+        }
+        this.el.val(this.count);
+    };
+    Counter.prototype.startCounting = function() {
+        this.id = setInterval(this.countDown.bind(this), this.delay);
+    };
+    Counter.prototype.stopCounting = function() {
+        this.started = false;
+        if (this.id) clearInterval(this.id);
+    };
+    var counter = new Counter("#counter", "1234", "fail", 4);
+    counter.el.val(counter.startNum);
+    counter.el.on("click", function(event) {
+        event.preventDefault();
+        if (counter.started) {
+            counter.started = false;
+            counter.stopCounting();
+        } else {
+            counter.started = true;
+            counter.count = counter.startNum;
+            counter.el.val(counter.startNum);
+            counter.startCounting();
         }
     });
 });

--- a/final_countdown.js
+++ b/final_countdown.js
@@ -23,12 +23,9 @@ $(document).ready(function() {
             started = true;
             count = startCount;
             counter.val(startCount);
-            queue = setInterval(function() {
-                var t0 = performance.now();
-                countDown();
-                var t1 = performance.now();
-                console.log("countDown call timed at " + (t1-t0) + " ms");
-            }, 0);
+            // The following should behave the same as setting the delay to 0
+            // in browsers that follow the HTML5 spec.
+            queue = setInterval(countDown, 4);
         }
     });
 });

--- a/final_countdown.js
+++ b/final_countdown.js
@@ -1,0 +1,29 @@
+$(document).ready(function() {
+    var counter = $("#counter");
+    var startCount = "1234";
+    var started = false;
+    var count, queue;
+    counter.val(startCount);
+    function countDown() {
+        count--;
+        if (count === 0) {
+            counter.addClass("fail");
+            clearInterval(queue);
+        } else {
+            counter.removeClass("fail");
+        }
+        counter.val(count);
+    }
+    counter.on("click", function(event) {
+        event.preventDefault();
+        if (started) {
+            started = false;
+            clearInterval(queue);
+        } else {
+            started = true;
+            count = startCount;
+            counter.val(startCount);
+            queue = setInterval(countDown, 0);
+        }
+    });
+});

--- a/final_countdown.js
+++ b/final_countdown.js
@@ -23,7 +23,12 @@ $(document).ready(function() {
             started = true;
             count = startCount;
             counter.val(startCount);
-            queue = setInterval(countDown, 0);
+            queue = setInterval(function() {
+                var t0 = performance.now();
+                countDown();
+                var t1 = performance.now();
+                console.log("countDown call timed at " + (t1-t0) + " ms");
+            }, 0);
         }
     });
 });

--- a/final_countdown.js
+++ b/final_countdown.js
@@ -9,12 +9,12 @@ $(document).ready(function() {
         this.delay = delay;
     }
     Counter.prototype.countDown = function() {
+        this.count--;
         if (this.count === 0) {
             this.started = false;
             this.el.addClass(this.failClass);
             this.stopCounting();
         } else {
-            this.count--;
             this.el.val(this.count);
             if (this.el.hasClass(this.failClass)) {
                 this.el.removeClass(this.failClass);

--- a/final_countdown.js
+++ b/final_countdown.js
@@ -7,6 +7,7 @@ $(document).ready(function() {
     function countDown() {
         count--;
         if (count === 0) {
+            started = false;
             counter.addClass("fail");
             clearInterval(queue);
         } else {

--- a/final_countdown.js
+++ b/final_countdown.js
@@ -2,16 +2,17 @@ $(document).ready(function() {
     var counter = $("#counter");
     var startCount = "1234";
     var started = false;
+    var zeroClass = "fail";
     var count, queue;
     counter.val(startCount);
     function countDown() {
         count--;
         if (count === 0) {
             started = false;
-            counter.addClass("fail");
+            counter.addClass(zeroClass);
             clearInterval(queue);
         } else {
-            counter.removeClass("fail");
+            if (counter.hasClass(zeroClass)) counter.removeClass(zeroClass);
         }
         counter.val(count);
     }

--- a/index.html
+++ b/index.html
@@ -55,9 +55,7 @@
       }
     </style>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-    <script>
-      // Put some code in here!
-    </script>
+    <script src="final_countdown.js"></script>
 
   </head>
   <body>


### PR DESCRIPTION
Comfort level with this started out puzzled, as I was curious about why I couldn't get the countdown to go faster.  But even when counting down with the [setInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setInterval) delay at 0 or 1 milliseconds, the full countdown seemed to be taking around 5 seconds, when it should be taking around 1.234 seconds.

My next inclination was to time the function used in setInterval to see if it was causing the bottleneck.  As JavaScript runs on a single thread, its setInterval functions must wait for the last executing function to finish executing before the next can start.  The browser engine builds a queue for these functions that take longer than the interval [1].  Thus, a function that would take around 4 milliseconds to execute would explain this behavior as the next interval would be constantly waiting around 3 ms before the previous interval finished.  But after timing the function, it clocked at around 0.1 ms.

From there, research directed me to the [setTimeout docs](https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setTimeout#Reasons_for_delays_longer_than_specified), and after reading through them more thoroughly, I realized that the [HTML5 spec](https://html.spec.whatwg.org/multipage/webappapis.html#timers) sets a minimum timer value of 4 milliseconds, which also gets applied to the `setInterval` method.  So, to conclude, it seems that in any browser that follows the HTML5 spec, a delay value < 4 sent to the `setInterval` or `setTimeout` methods will likely be overridden by the minimum timer value (4).

[1][http://ejohn.org/blog/how-javascript-timers-work/](http://ejohn.org/blog/how-javascript-timers-work/)
